### PR TITLE
Quectel BG770 Communication Improvements

### DIFF
--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -383,7 +383,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
 
         if( cellularStatus == CELLULAR_SUCCESS )
         {
-            /* Disable echo. */
+            /* Disable echo - command is not automatically saved to user profile, don't need to perform read before write. */
             atReqGetWithResult.pAtCmd = "ATE0";
             cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetWithResult );
             if( cellularStatus == CELLULAR_SUCCESS )
@@ -398,7 +398,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
 
         if( cellularStatus == CELLULAR_SUCCESS )
         {
-            /* Disable DTR function. */
+            /* Disable DTR function - command is not automatically saved to user profile, don't need to perform read before write. */
             atReqGetNoResult.pAtCmd = "AT&D0";
             cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
             if( cellularStatus == CELLULAR_SUCCESS )
@@ -416,7 +416,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             {
                 vTaskDelay( SHORT_DELAY_ticks );
 
-                /* Enable RTS/CTS hardware flow control. */
+                /* Enable RTS/CTS hardware flow control - command is not saved to user profile, don't need to perform read before write. . */
                 atReqGetNoResult.pAtCmd = "AT+IFC=2,2";
                 cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
                 if( cellularStatus == CELLULAR_SUCCESS )
@@ -463,13 +463,19 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             }
         }
 
-#ifdef CELLULAR_QUECTEL_ENABLE_DEBUG_UART
+//#define CELLULAR_QUECTEL_ENABLE_DEBUG_UART
+//#define CELLULAR_QUECTEL_DISABLE_DEBUG_UART
+#if defined(CELLULAR_QUECTEL_ENABLE_DEBUG_UART) || defined(CELLULAR_QUECTEL_DISABLE_DEBUG_UART)
         if( cellularStatus == CELLULAR_SUCCESS )
         {
             vTaskDelay( SHORT_DELAY_ticks );
 
             /* Setting debug output enable. */
+#ifdef CELLULAR_QUECTEL_ENABLE_DEBUG_UART
             atReqGetNoResult.pAtCmd = "AT+QCFGEXT=\"debug\",1";
+#else
+            atReqGetNoResult.pAtCmd = "AT+QCFGEXT=\"debug\",0";
+#endif
             CellularError_t debugResult = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
             if( debugResult == CELLULAR_SUCCESS )
             {
@@ -486,6 +492,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
         }
 #endif
 
+        // TODO (MV): Implement read before write
         if( cellularStatus == CELLULAR_SUCCESS )
         {
             vTaskDelay( SHORT_DELAY_ticks );
@@ -510,6 +517,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             LogWarn( ( "Cellular_ModuleEnableUE: eMTC (LTE-M) only network category skipped due to error" ) );
         }
 
+        // TODO (MV): Implement read before write
         if( cellularStatus == CELLULAR_SUCCESS )
         {
             vTaskDelay( SHORT_DELAY_ticks );
@@ -547,6 +555,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             LogWarn( ( "Cellular_ModuleEnableUE: Network scan RAT list skipped due to error" ) );
         }
 
+        // TODO (MV): Implement read before write
         if( cellularStatus == CELLULAR_SUCCESS )
         {
             vTaskDelay( SHORT_DELAY_ticks );
@@ -570,6 +579,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             LogWarn( ( "Cellular_ModuleEnableUE: Skipped Set RF off / SIM enabled due to error" ) );
         }
 
+        // TODO (MV): Implement read before write
         if( cellularStatus == CELLULAR_SUCCESS )
         {
             vTaskDelay( SHORT_DELAY_ticks );

--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -492,6 +492,35 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
         }
 #endif
 
+//#define CELLULAR_QUECTEL_ENABLE_USB
+//#define CELLULAR_QUECTEL_DISABLE_USB
+#if defined(CELLULAR_QUECTEL_ENABLE_USB) || defined(CELLULAR_QUECTEL_DISABLE_USB)
+        if( cellularStatus == CELLULAR_SUCCESS )
+        {
+            vTaskDelay( SHORT_DELAY_ticks );
+
+            /* Setting debug output enable. */
+#ifdef CELLULAR_QUECTEL_ENABLE_USB
+            atReqGetNoResult.pAtCmd = "AT+QCFG=\"usb\",1";
+#else
+            atReqGetNoResult.pAtCmd = "AT+QCFG=\"usb\",0";
+#endif
+            CellularError_t debugResult = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
+            if( debugResult == CELLULAR_SUCCESS )
+            {
+                LogInfo( ( "Cellular_ModuleEnableUE: '%s' command success.", atReqGetNoResult.pAtCmd ) );
+            }
+            else
+            {
+                LogWarn( ( "Cellular_ModuleEnableUE: '%s' command failed.", atReqGetNoResult.pAtCmd ) );
+            }
+        }
+        else
+        {
+            LogWarn( ( "Cellular_ModuleEnableUE: USB enable skipped due to error" ) );
+        }
+#endif
+
         // TODO (MV): Implement read before write
         if( cellularStatus == CELLULAR_SUCCESS )
         {

--- a/source/cellular_bg770.h
+++ b/source/cellular_bg770.h
@@ -63,6 +63,10 @@
 
 #define PSM_VERSION_BIT_MASK               ( 0b00001111u )
 
+#include <cellular_types.h>
+#include "cellular_platform.h"
+#include "cellular_common.h"
+
 /**
  * @brief DNS query result.
  */
@@ -73,6 +77,13 @@ typedef enum cellularDnsQueryResult
     CELLULAR_DNS_QUERY_MAX,
     CELLULAR_DNS_QUERY_UNKNOWN
 } cellularDnsQueryResult_t;
+
+typedef enum CellularModuleFullInitSkippedResult
+{
+    CELLULAR_FULL_INIT_SKIPPED_RESULT_YES,
+    CELLULAR_FULL_INIT_SKIPPED_RESULT_NO,
+    CELLULAR_FULL_INIT_SKIPPED_RESULT_ERROR     /* Error caused yes/no result to be irrelevant */
+} CellularModuleFullInitSkippedResult_t;
 
 typedef struct cellularModuleContext cellularModuleContext_t;
 
@@ -114,6 +125,30 @@ extern uint32_t CellularSrcTokenSuccessTableSize;
 
 extern const char * CellularUrcTokenWoPrefixTable[];
 extern uint32_t CellularUrcTokenWoPrefixTableSize;
+
+/**
+ * @brief Set whether to skip all configuration of the BG770 that occurs after the H/W flow control setting if the
+ *        H/W flow control setting changed.
+ *
+ * @param[in] skipPostHWFlowControlSetupIfChanged Boolean of whether to skip all setup after setting H/W flow control
+ *                                                mode if flow control mode changed.
+ *
+ * @return CELLULAR_SUCCESS if the operation is successful, otherwise an error
+ * code indicating the cause of the error.
+ */
+CellularError_t CellularModule_SkipInitializationPostHWFlowControlSetupIfChanged(
+        bool skipPostHWFlowControlSetupIfChanged);
+
+/**
+ * @brief Retrieve whether post H/W flow control initialization was skipped.
+ *
+ * @param[out] pSkippedResult pointer to memory to place result.
+ *
+ * @return CELLULAR_SUCCESS if the operation is successful, otherwise an error
+ * code indicating the cause of the error.
+ */
+CellularError_t CellularModule_TryGetDidSkipInitializationPostHWFlowControlSetup(
+        CellularModuleFullInitSkippedResult_t * pSkippedResult);
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/cellular_bg770.h
+++ b/source/cellular_bg770.h
@@ -129,6 +129,7 @@ extern uint32_t CellularUrcTokenWoPrefixTableSize;
 /**
  * @brief Set whether to skip all configuration of the BG770 that occurs after the H/W flow control setting if the
  *        H/W flow control setting changed.
+ *        NOTE: Not thread safe, expected to be called when Cellular_Init() is not running, ideally from the same thread.
  *
  * @param[in] skipPostHWFlowControlSetupIfChanged Boolean of whether to skip all setup after setting H/W flow control
  *                                                mode if flow control mode changed.
@@ -141,6 +142,7 @@ CellularError_t CellularModule_SkipInitializationPostHWFlowControlSetupIfChanged
 
 /**
  * @brief Retrieve whether post H/W flow control initialization was skipped.
+ *        NOTE: Not thread safe, expected to be called when Cellular_Init() is not running, ideally from the same thread.
  *
  * @param[out] pSkippedResult pointer to memory to place result.
  *

--- a/source/cellular_bg770_api.c
+++ b/source/cellular_bg770_api.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <ctype.h>
+#include <assert.h>
 
 /* The config header is always included first. */
 #ifndef CELLULAR_DO_NOT_USE_CUSTOM_CONFIG

--- a/source/cellular_bg770_urc_handler.c
+++ b/source/cellular_bg770_urc_handler.c
@@ -910,7 +910,7 @@ static void _Cellular_ProcessPSMTimerurc(CellularContext_t * pContext,
     else
     {
         // FUTURE: Pass timer info through modem event callback
-        LogDebug( ( "_Cellular_ProcessPSMTimerurc: Modem PSM timer start event received" ) );
+        LogDebug( ( "_Cellular_ProcessPSMTimerurc: Modem PSM timer event received, '%s'", pInputLine ) );
         _Cellular_ModemEventCallback( pContext, CELLULAR_MODEM_EVENT_PSM_TIMER );
     }
 }


### PR DESCRIPTION
- added side access methods (ie. don't go through FreeRTOS-Cellular-Interface API) in order to return from Cellular_Init() early if hardware flow control setting changed and to query whether early return occurred. Necessary to change UART configuration before restarting Cellular_Init()
- read all persisted settings and only write if different than desired (precaution to reduce chances of Quectel file system corruption)
- added implementation of Cellular_GetPdnConfig() [new API function]