### PR TITLE
Firmware Improvements (PSM support and Quectel FLASH service life)

### DIFF
--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -105,6 +105,18 @@ static const char *const UE_FUNC_LEVEL_SIM_ONLY_STRING = "4";
 /* SIM enabled, RF off. Need to set additional settings before modem tries to connect. */
 static const BG770UEFunctionalityLevel_t DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL = BG770_UE_FUNCTIONALITY_LEVEL_SIM_ONLY;
 
+typedef enum BG770TimeZoneReportingMode
+{
+    BG770_TZ_REPORTING_MODE_DISABLED = 0,         /**< Disable time zone change event reporting */
+    BG770_TZ_REPORTING_MODE_ENABLED = 1,          /**< Enable time zone change event reporting by unsolicited result code +CTZV: <tz> */
+    BG770_TZ_REPORTING_MODE_ENABLED_EXTENDED = 2, /**< Enable extended time zone and local time reporting by unsolicited result code: +CTZE: <tz>,<dst>,<time> */
+    BG770_TZ_REPORTING_MODE_UNKNOWN,              /**< Unknown/unsupported time zone reporting mode. */
+} BG770TimeZoneReportingMode_t;
+
+static const char *const TIME_ZONE_REPORTING_MODE_DISABLED_STRING = "0";
+static const char *const TIME_ZONE_REPORTING_MODE_ENABLED_STRING = "1";
+static const char *const TIME_ZONE_REPORTING_MODE_ENABLED_EXTENDED_STRING = "2";
+
 typedef enum BG770NetworkCategorySearchMode
 {
     BG770_NETWORK_CATEGORY_SEARCH_MODE_eMTC = 0,            /**< eMTC/LTE-M. */
@@ -249,6 +261,12 @@ static bool areRATScanSequencesEquivalent( const BG770RATScanSequence_t * sequen
 
 static bool tryBuildRATScanSequenceString( const BG770RATScanSequence_t * pRATScanSequence,
                                            char * out_pRATScanSequenceString, size_t maxStringLength );
+
+static CellularError_t _GetPsmUrcEnabled( CellularHandle_t cellularHandle,
+                                          bool * pIsPsmUrcEnabled );
+
+static CellularError_t _GetTimeZoneReportingMode( CellularHandle_t cellularHandle,
+                                                  BG770TimeZoneReportingMode_t *pTimeZoneReportingMode );
 
 /*-----------------------------------------------------------*/
 
@@ -561,7 +579,6 @@ CellularError_t Cellular_ModuleCleanUp( const CellularContext_t * pContext )
 CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
 {
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
-    char cmdBuf[ CELLULAR_AT_CMD_MAX_SIZE ] = { '\0' };
     CellularAtReq_t atReqGetNoResult =
     {
         NULL,
@@ -992,15 +1009,10 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             vTaskDelay( SHORT_DELAY_ticks );
 
             /* Disable LwM2M (automatically turned on with Verizon SIM, LwM2M can change APN and mess with normal DNS lookups) */
-            /* MISRA Ref 21.6.1 [Use of snprintf] */
-            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Cellular-Interface/blob/main/MISRA.md#rule-216 */
-            /* coverity[misra_c_2012_rule_21_6_violation]. */
-            ( void ) snprintf( cmdBuf, sizeof ( cmdBuf ), "AT+QCFG=\"lwm2m\",0" );
-
-            atReqGetNoResult.pAtCmd = cmdBuf;
+            atReqGetNoResult.pAtCmd = "AT+QCFG=\"lwm2m\",0";
 
             bool isLwM2MEnabled = false;
-            CellularError_t getLwM2MEnableStatus = _GetLwM2MEnabled(pContext, &isLwM2MEnabled );
+            const CellularError_t getLwM2MEnableStatus = _GetLwM2MEnabled(pContext, &isLwM2MEnabled );
             if( getLwM2MEnableStatus != CELLULAR_SUCCESS || isLwM2MEnabled )
             {
                 vTaskDelay( SHORT_DELAY_ticks );
@@ -1037,6 +1049,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
 CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
 {
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     CellularAtReq_t atReqGetNoResult =
     {
         NULL,
@@ -1053,37 +1066,109 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
         return cellularStatus;
     }
 
-    /* FUTURE: Turn all of these commands into read before write */
-
-    // TODO (MV): Make these indicate error if occurs
-
+    // TODO (MV): Make this command read before write
     /* Set numeric operator format. */
     atReqGetNoResult.pAtCmd = "AT+COPS=3,2";
-    ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
+    pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
+    if( pktStatus != CELLULAR_PKT_STATUS_OK )
+    {
+        LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
+                     atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
+    }
 
     /* Enable network registration and location information unsolicited result code:
-        +CREG: <stat>[,[<lac>],[<ci>],[<AcT>]]
+     *  +CREG: <stat>[,[<lac>],[<ci>],[<AcT>]]
+     * NOTE: Command is not automatically saved, therefore, don't need read-before-write behavior
      */
     atReqGetNoResult.pAtCmd = "AT+CREG=2";
-    ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
+    pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
+    if( pktStatus != CELLULAR_PKT_STATUS_OK )
+    {
+        LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
+                     atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
+    }
 
     /* Enable LTE network registration and location information unsolicited result code:
-     // TODO (MV): Finish this
-    +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>[,<cause_type>,<reject_cause>]]]
-    +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>[,<cause_type>,<reject_cause>]]]
+     * <n> = 2:
+     *  +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>[,<cause_type>,<reject_cause>]]]
+     * <n> = 4:
+     *  +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>[,[<Active-Time>],[<Periodic-TAU>]]]
+     * NOTE: Command is not automatically saved, therefore, don't need read-before-write behavior
      */
     atReqGetNoResult.pAtCmd = "AT+CEREG=2";
-    ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
+    pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
+    if( pktStatus != CELLULAR_PKT_STATUS_OK )
+    {
+        LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
+                     atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
+    }
+
+    vTaskDelay( SHORT_DELAY_ticks );
 
     /* Enable time zone change event reporting by unsolicited result code +CTZV: <tz> */
     atReqGetNoResult.pAtCmd = "AT+CTZR=1";
-    ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
+
+    BG770TimeZoneReportingMode_t timeZoneReportingMode = BG770_TZ_REPORTING_MODE_UNKNOWN;
+    cellularStatus = _GetTimeZoneReportingMode( pContext, &timeZoneReportingMode );
+    if( ( cellularStatus != CELLULAR_SUCCESS ) ||
+        ( BG770_TZ_REPORTING_MODE_ENABLED != timeZoneReportingMode ) )
+    {
+        vTaskDelay( SHORT_DELAY_ticks );
+
+        if( cellularStatus != CELLULAR_SUCCESS )
+        {
+            LogError( ( "Cellular_ModuleEnableUrc: Could not get TZ reporting mode, assuming not already set." ) );
+        }
+
+        cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
+        if( cellularStatus == CELLULAR_SUCCESS )
+        {
+            LogInfo( ( "Cellular_ModuleEnableUrc: '%s' command success.", atReqGetNoResult.pAtCmd ) );
+        }
+        else
+        {
+            LogError( ( "Cellular_ModuleEnableUrc: '%s' command failed (err: %s [%d]).",
+                        atReqGetNoResult.pAtCmd, getCellularErrorString(cellularStatus), cellularStatus ) );
+        }
+    }
+    else
+    {
+        LogInfo( ( "Cellular_ModuleEnableUrc: '%s' command skipped, already set.", atReqGetNoResult.pAtCmd ) );
+    }
+
+    vTaskDelay( SHORT_DELAY_ticks );
 
     /* Enable PSM URC reporting by unsolicited result code +QPSMTIMER: <TAU_timer>,<T3324_timer> */
-    atReqGetNoResult.pAtCmd = "AT+QCFG=\"psm/urc\",1";  // TODO (MV): Fix this
-    ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
+    atReqGetNoResult.pAtCmd = "AT+QCFG=\"psm/urc\",1";
 
-    return cellularStatus;
+    bool isPsmUrcEnabled = false;
+    cellularStatus = _GetPsmUrcEnabled(pContext, &isPsmUrcEnabled );
+    if( ( cellularStatus != CELLULAR_SUCCESS ) || ( isPsmUrcEnabled != true /* extra thorough condition */ ) )
+    {
+        vTaskDelay( SHORT_DELAY_ticks );
+
+        if( cellularStatus != CELLULAR_SUCCESS )
+        {
+            LogError( ( "Cellular_ModuleEnableUrc: Could not get PSM URC enabled, assuming not already set." ) );
+        }
+
+        cellularStatus = sendAtCommandWithRetryTimeout( pContext, &atReqGetNoResult );
+        if( cellularStatus == CELLULAR_SUCCESS )
+        {
+            LogInfo( ( "Cellular_ModuleEnableUrc: '%s' command success.", atReqGetNoResult.pAtCmd ) );
+        }
+        else
+        {
+            LogError( ( "Cellular_ModuleEnableUrc: '%s' command failed (err: %s [%d]).",
+                        atReqGetNoResult.pAtCmd, getCellularErrorString(cellularStatus), cellularStatus ) );
+        }
+    }
+    else
+    {
+        LogInfo( ( "Cellular_ModuleEnableUrc: '%s' command skipped, already set.", atReqGetNoResult.pAtCmd ) );
+    }
+
+    return CELLULAR_SUCCESS;    // always success even if commands fail
 }
 
 /*-----------------------------------------------------------*/
@@ -2843,3 +2928,311 @@ static CellularError_t _SetRATScanSequence( CellularHandle_t cellularHandle,
 
     return cellularStatus;
 }
+
+/*-----------------------------------------------------------*/
+
+static bool _parsePsmUrcEnable( char * pQcfgPsmUrcPayload,
+                                bool * pIsPsmUrcEnabled )
+{
+    char * pToken = NULL, * pTmpQcfgPsmUrcPayload = pQcfgPsmUrcPayload;
+    bool parseStatus = true;
+    CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
+    int32_t tempValue = 0;
+
+    if( ( pIsPsmUrcEnabled == NULL ) || ( pQcfgPsmUrcPayload == NULL ) )
+    {
+        LogError( ( "_GetPsmUrcEnabled: Invalid Input Parameters" ) );
+        parseStatus = false;
+    }
+
+    if( parseStatus == true )
+    {
+        if( Cellular_ATGetNextTok( &pTmpQcfgPsmUrcPayload, &pToken ) != CELLULAR_AT_SUCCESS ||
+            strcmp( pToken, "\"psm/urc\"" ) != 0 )
+        {
+            LogError( ( "_GetPsmUrcEnabled: Error, missing \"psm/urc\"" ) );
+            parseStatus = false;
+        }
+    }
+
+    if( parseStatus == true )
+    {
+        if( Cellular_ATGetNextTok( &pTmpQcfgPsmUrcPayload, &pToken ) == CELLULAR_AT_SUCCESS )
+        {
+            atCoreStatus = Cellular_ATStrtoi( pToken, 10, &tempValue );
+            if( atCoreStatus == CELLULAR_AT_SUCCESS)
+            {
+                if( ( tempValue >= 0 ) && ( tempValue <= ( int32_t ) 1 ) )
+                {
+                    *pIsPsmUrcEnabled = ( tempValue == 1 );
+                }
+                else
+                {
+                    atCoreStatus = CELLULAR_AT_ERROR;
+                }
+            }
+
+            if( atCoreStatus != CELLULAR_AT_SUCCESS )
+            {
+                LogError( ( "_GetPsmUrcEnabled: Error in processing enable. Token %s", pToken ) );
+                *pIsPsmUrcEnabled = false;
+                parseStatus = false;
+            }
+        }
+        else
+        {
+            LogError( ( "_GetPsmUrcEnabled: enable not present" ) );
+            *pIsPsmUrcEnabled = false;
+            parseStatus = false;
+        }
+    }
+    else
+    {
+        if( pIsPsmUrcEnabled != NULL )
+        {
+            *pIsPsmUrcEnabled = false;
+        }
+    }
+
+    return parseStatus;
+}
+
+/* FreeRTOS Cellular Library types. */
+/* coverity[misra_c_2012_rule_8_13_violation] */
+static CellularPktStatus_t _RecvFuncGetPsmUrcEnable( CellularContext_t * pContext,
+                                                     const CellularATCommandResponse_t * pAtResp,
+                                                     void * pData,
+                                                     uint16_t dataLen )
+{
+    char * pInputLine = NULL;
+    bool * pIsPsmUrcEnabled = ( bool * ) pData;
+    bool parseStatus = true;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
+
+    if( pContext == NULL )
+    {
+        pktStatus = CELLULAR_PKT_STATUS_INVALID_HANDLE;
+    }
+    else if( ( pIsPsmUrcEnabled == NULL ) || ( dataLen != sizeof( bool ) ) )
+    {
+        pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
+    }
+    else if( ( pAtResp == NULL ) || ( pAtResp->pItm == NULL ) || ( pAtResp->pItm->pLine == NULL ) )
+    {
+        LogError( ( "_GetPsmUrcEnabled: Input Line passed is NULL" ) );
+        pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+    }
+    else
+    {
+        pInputLine = pAtResp->pItm->pLine;
+        atCoreStatus = Cellular_ATRemovePrefix( &pInputLine );
+
+        if( atCoreStatus == CELLULAR_AT_SUCCESS )
+        {
+            atCoreStatus = Cellular_ATRemoveAllWhiteSpaces( pInputLine );
+        }
+
+        if( atCoreStatus != CELLULAR_AT_SUCCESS )
+        {
+            pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
+        }
+    }
+
+    if( pktStatus == CELLULAR_PKT_STATUS_OK )
+    {
+        parseStatus = _parsePsmUrcEnable( pInputLine, pIsPsmUrcEnabled );
+
+        if( parseStatus != true )
+        {
+            *pIsPsmUrcEnabled = false;
+            pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+        }
+    }
+
+    return pktStatus;
+}
+
+static CellularError_t _GetPsmUrcEnabled( CellularHandle_t cellularHandle,
+                                          bool * pIsPsmUrcEnabled )
+{
+    CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularAtReq_t atReqGetLwM2MEnable =
+    {
+        "AT+QCFG=\"psm/urc\"",
+        CELLULAR_AT_WITH_PREFIX,
+        "+QCFG",
+        _RecvFuncGetPsmUrcEnable,
+        pIsPsmUrcEnabled,
+        sizeof( bool ),
+    };
+
+    if( pIsPsmUrcEnabled == NULL )
+    {
+        cellularStatus = CELLULAR_BAD_PARAMETER;
+    }
+    else
+    {
+        pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetLwM2MEnable );
+
+        if( pktStatus != CELLULAR_PKT_STATUS_OK )
+        {
+            LogError( ( "_GetPsmUrcEnabled: couldn't retrieve PSM URC enable (pktStatus: %s [%d]).",
+                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+            cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
+        }
+    }
+
+    return cellularStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+/**< NOTE: pTimeZoneReportingModeString is expected to contain no whitespace. */
+static BG770TimeZoneReportingMode_t _getTimeZoneReportingMode( const char * pTimeZoneReportingModeString )
+{
+    if( strcmp( pTimeZoneReportingModeString, TIME_ZONE_REPORTING_MODE_DISABLED_STRING ) == 0 )
+    {
+        return BG770_TZ_REPORTING_MODE_DISABLED;
+    }
+    else if ( strcmp( pTimeZoneReportingModeString, TIME_ZONE_REPORTING_MODE_ENABLED_STRING ) == 0 )
+    {
+        return BG770_TZ_REPORTING_MODE_ENABLED;
+    }
+    else if ( strcmp( pTimeZoneReportingModeString, TIME_ZONE_REPORTING_MODE_ENABLED_EXTENDED_STRING ) == 0 )
+    {
+        return BG770_TZ_REPORTING_MODE_ENABLED_EXTENDED;
+    }
+    else
+    {
+        return BG770_TZ_REPORTING_MODE_UNKNOWN;
+    }
+}
+
+static bool _parseTimeZoneReportingMode( char * pQTimeZoneReportingModePayload,
+                                         BG770TimeZoneReportingMode_t *const pTimeZoneReportingMode )
+{
+    char * pToken = NULL, * pTmpQTimeZoneReportingMode = pQTimeZoneReportingModePayload;
+    bool parseStatus = true;
+
+    if( ( pTimeZoneReportingMode == NULL ) || ( pQTimeZoneReportingModePayload == NULL ) )
+    {
+        LogError( ( "_parseTimeZoneReportingMode: Invalid Input Parameters" ) );
+        parseStatus = false;
+    }
+
+    if( parseStatus == true )
+    {
+        if( Cellular_ATGetNextTok( &pTmpQTimeZoneReportingMode, &pToken ) == CELLULAR_AT_SUCCESS )
+        {
+            *pTimeZoneReportingMode = _getTimeZoneReportingMode( pToken );
+            if( *pTimeZoneReportingMode == BG770_TZ_REPORTING_MODE_UNKNOWN ) {
+                LogError( ( "_parseTimeZoneReportingMode: time zone reporting mode invalid, '%s'", pToken ) );
+                parseStatus = false;
+            }
+        }
+        else
+        {
+            LogError( ( "_parseTimeZoneReportingMode: time zone reporting mode string not present" ) );
+            *pTimeZoneReportingMode = BG770_TZ_REPORTING_MODE_UNKNOWN;
+            parseStatus = false;
+        }
+    }
+
+    return parseStatus;
+}
+
+/* FreeRTOS Cellular Library types. */
+/* coverity[misra_c_2012_rule_8_13_violation] */
+static CellularPktStatus_t _RecvFuncGetTimeZoneReportingMode( CellularContext_t * pContext,
+                                                              const CellularATCommandResponse_t * pAtResp,
+                                                              void * pData,
+                                                              uint16_t dataLen )
+{
+    char * pInputLine = NULL;
+    BG770TimeZoneReportingMode_t * pTimeZoneReportingMode = ( BG770TimeZoneReportingMode_t * ) pData;
+    bool parseStatus = true;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
+
+    if( pContext == NULL )
+    {
+        pktStatus = CELLULAR_PKT_STATUS_INVALID_HANDLE;
+    }
+    else if( ( pTimeZoneReportingMode == NULL ) || ( dataLen != sizeof( BG770TimeZoneReportingMode_t ) ) )
+    {
+        pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
+    }
+    else if( ( pAtResp == NULL ) || ( pAtResp->pItm == NULL ) || ( pAtResp->pItm->pLine == NULL ) )
+    {
+        LogError( ( "_GetTimeZoneReportingMode: Input Line passed is NULL" ) );
+        pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+    }
+    else
+    {
+        pInputLine = pAtResp->pItm->pLine;
+        atCoreStatus = Cellular_ATRemovePrefix( &pInputLine );
+
+        if( atCoreStatus == CELLULAR_AT_SUCCESS )
+        {
+            atCoreStatus = Cellular_ATRemoveAllWhiteSpaces( pInputLine );
+        }
+
+        if( atCoreStatus != CELLULAR_AT_SUCCESS )
+        {
+            pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
+        }
+    }
+
+    if( pktStatus == CELLULAR_PKT_STATUS_OK )
+    {
+        parseStatus = _parseTimeZoneReportingMode( pInputLine, pTimeZoneReportingMode );
+
+        if( parseStatus != true )
+        {
+            *pTimeZoneReportingMode = BG770_TZ_REPORTING_MODE_UNKNOWN;
+            pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+        }
+    }
+
+    return pktStatus;
+}
+
+static CellularError_t _GetTimeZoneReportingMode( CellularHandle_t cellularHandle,
+                                                  BG770TimeZoneReportingMode_t *const pTimeZoneReportingMode )
+{
+    CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularAtReq_t atReqGetTimeZoneReportingMode =
+    {
+        "AT+CTZR?",
+        CELLULAR_AT_WITH_PREFIX,
+        "+CTZR",
+        _RecvFuncGetTimeZoneReportingMode,
+        pTimeZoneReportingMode,
+        sizeof( BG770TimeZoneReportingMode_t ),
+    };
+
+    if( pTimeZoneReportingMode == NULL )
+    {
+        cellularStatus = CELLULAR_BAD_PARAMETER;
+    }
+    else
+    {
+        pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetTimeZoneReportingMode );
+
+        if( pktStatus != CELLULAR_PKT_STATUS_OK )
+        {
+            LogError( ( "_GetTimeZoneReportingMode: couldn't retrieve time zone reporting mode (pktStatus: %s [%d]).",
+                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+            cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
+        }
+    }
+
+    return cellularStatus;
+}
+
+/*-----------------------------------------------------------*/

--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -1077,16 +1077,6 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
         return cellularStatus;
     }
 
-    // TODO (MV): Make this command read before write
-    /* Set numeric operator format. */
-    atReqGetNoResult.pAtCmd = "AT+COPS=3,2";
-    pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
-    if( pktStatus != CELLULAR_PKT_STATUS_OK )
-    {
-        LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
-                     atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
-    }
-
     /* Enable network registration and location information unsolicited result code:
      *  +CREG: <stat>[,[<lac>],[<ci>],[<AcT>]]
      * NOTE: Command is not automatically saved, therefore, don't need read-before-write behavior
@@ -1102,6 +1092,8 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
         LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
                      atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
     }
+
+    vTaskDelay( SHORT_DELAY_ticks );
 
     /* Enable LTE network registration and location information unsolicited result code:
      * <n> = 2:

--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -102,8 +102,12 @@ static const char *const UE_FUNC_LEVEL_MINIMUM_STRING = "0";
 static const char *const UE_FUNC_LEVEL_FULL_STRING = "1";
 static const char *const UE_FUNC_LEVEL_SIM_ONLY_STRING = "4";
 
+#ifdef CELLULAR_CONFIG_FORCE_FUNCTIONALITY_LEVEL_SIM_ONLY_RF_OFF
+
 /* SIM enabled, RF off. Need to set additional settings before modem tries to connect. */
 static const BG770UEFunctionalityLevel_t DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL = BG770_UE_FUNCTIONALITY_LEVEL_SIM_ONLY;
+
+#endif
 
 typedef enum BG770TimeZoneReportingMode
 {
@@ -218,11 +222,15 @@ static CellularError_t _GetUEFunctionalityLevelWithRetryTimeout( CellularHandle_
                                                                  uint32_t commandTimeoutMS,
                                                                  uint32_t exponentialBackoffInterCommandBaseMS );
 
+#ifdef CELLULAR_CONFIG_FORCE_FUNCTIONALITY_LEVEL_SIM_ONLY_RF_OFF
+
 static CellularError_t _SetUEFunctionalityLevel( CellularHandle_t cellularHandle,
                                                  BG770UEFunctionalityLevel_t ueFunctionalityLevel,
                                                  uint32_t commandTimeoutMS );
 
 static CellularError_t _SetDesiredUEFunctionalityLevel( CellularHandle_t cellularHandle, uint32_t commandTimeoutMS );
+
+#endif
 
 static CellularError_t _GetNetworkCategorySearchMode( CellularHandle_t cellularHandle,
                                                       BG770NetworkCategorySearchMode_t * pNetworkCategorySearchMode,
@@ -755,38 +763,41 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
                 LogInfo( ( "Cellular_ModuleEnableUE: UE functionality level (%d) on boot.", ueFunctionalityLevel ) );
             }
 
-            // TODO (MV): Fix this
-            // if( cellularStatus != CELLULAR_SUCCESS ||
-            //     DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL != ueFunctionalityLevel )
-            // {
-            //     if( cellularStatus != CELLULAR_SUCCESS )
-            //     {
-            //         LogError( ( "Cellular_ModuleEnableUE: Could not get UE functionality level, assuming not already set." ) );
-            //     }
-            //
-            //     cellularStatus = setRetryableSettingWithTimeoutParams(
-            //             _SetDesiredUEFunctionalityLevel, pContext, ENABLE_MODULE_UE_RETRY_TIMEOUT_MS,
-            //             ENABLE_MODULE_UE_RETRY_EXP_BACKOFF_INTER_COMMAND_BASE_MS );
-            //     if( cellularStatus == CELLULAR_SUCCESS )
-            //     {
-            //         LogInfo( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command success.", DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL ) );
-            //     }
-            //     else
-            //     {
-            //         LogError( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command failure (err: %s [%d]), current level: %d.",
-            //                     DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL,
-            //                     getCellularErrorString(cellularStatus), cellularStatus,
-            //                     ueFunctionalityLevel ) );
-            //     }
-            // }
-            // else
-            // {
-            //     LogInfo( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command skipped, already set.", DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL ) );
-            // }
+#ifdef CELLULAR_CONFIG_FORCE_FUNCTIONALITY_LEVEL_SIM_ONLY_RF_OFF
+            if( cellularStatus != CELLULAR_SUCCESS ||
+                DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL != ueFunctionalityLevel )
+            {
+                if( cellularStatus != CELLULAR_SUCCESS )
+                {
+                    LogError( ( "Cellular_ModuleEnableUE: Could not get UE functionality level, assuming not already set." ) );
+                }
+
+                cellularStatus = setRetryableSettingWithTimeoutParams(
+                        _SetDesiredUEFunctionalityLevel, pContext, ENABLE_MODULE_UE_RETRY_TIMEOUT_MS,
+                        ENABLE_MODULE_UE_RETRY_EXP_BACKOFF_INTER_COMMAND_BASE_MS );
+                if( cellularStatus == CELLULAR_SUCCESS )
+                {
+                    LogInfo( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command success.", DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL ) );
+                }
+                else
+                {
+                    LogError( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command failure (err: %s [%d]), current level: %d.",
+                                DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL,
+                                getCellularErrorString(cellularStatus), cellularStatus,
+                                ueFunctionalityLevel ) );
+                }
+            }
+            else
+            {
+                LogInfo( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command skipped, already set.", DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL ) );
+            }
+#endif
         }
         else
         {
+#ifdef CELLULAR_CONFIG_FORCE_FUNCTIONALITY_LEVEL_SIM_ONLY_RF_OFF
             LogWarn( ( "Cellular_ModuleEnableUE: Skipped Set RF off / SIM enabled due to error." ) );
+#endif
         }
 
         if( cellularStatus == CELLULAR_SUCCESS )
@@ -1082,7 +1093,11 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
      */
     atReqGetNoResult.pAtCmd = "AT+CREG=2";
     pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
-    if( pktStatus != CELLULAR_PKT_STATUS_OK )
+    if( pktStatus == CELLULAR_PKT_STATUS_OK )
+    {
+        LogInfo( ( "Cellular_ModuleEnableUrc: '%s' command success", atReqGetNoResult.pAtCmd ) );
+    }
+    else
     {
         LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
                      atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
@@ -1090,14 +1105,18 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
 
     /* Enable LTE network registration and location information unsolicited result code:
      * <n> = 2:
-     *  +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>[,<cause_type>,<reject_cause>]]]
+     *  +CEREG: <stat>[,[<tac>],[<ci>],[<AcT>[,<cause_type>,<reject_cause>]]]
      * <n> = 4:
-     *  +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>[,[<Active-Time>],[<Periodic-TAU>]]]
+     *  +CEREG: <stat>[,[<tac>],[<ci>],[<AcT>][,,[,[<Active-Time>],[<Periodic-TAU>]]]]
      * NOTE: Command is not automatically saved, therefore, don't need read-before-write behavior
      */
-    atReqGetNoResult.pAtCmd = "AT+CEREG=2";
+    atReqGetNoResult.pAtCmd = "AT+CEREG=4";
     pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
-    if( pktStatus != CELLULAR_PKT_STATUS_OK )
+    if( pktStatus == CELLULAR_PKT_STATUS_OK )
+    {
+        LogInfo( ( "Cellular_ModuleEnableUrc: '%s' command success", atReqGetNoResult.pAtCmd ) );
+    }
+    else
     {
         LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
                      atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
@@ -1903,27 +1922,6 @@ static BG770UEFunctionalityLevel_t _getUEFunctionalityLevel( const char * pFunct
     }
 }
 
-static const char * _getUEFunctionalityLevelString( const BG770UEFunctionalityLevel_t ueFunctionalityLevel )
-{
-    switch( ueFunctionalityLevel )
-    {
-        case BG770_UE_FUNCTIONALITY_LEVEL_MINIMUM:
-            return UE_FUNC_LEVEL_MINIMUM_STRING;
-
-        case BG770_UE_FUNCTIONALITY_LEVEL_FULL:
-            return UE_FUNC_LEVEL_FULL_STRING;
-
-        case BG770_UE_FUNCTIONALITY_LEVEL_SIM_ONLY:
-            return UE_FUNC_LEVEL_SIM_ONLY_STRING;
-
-        default:
-            LogError( ( "_getUEFunctionalityLevelString: Invalid BG770UEFunctionalityLevel_t: %d", ueFunctionalityLevel ) );
-            /**< Intentional fall-through */
-        case BG770_UE_FUNCTIONALITY_LEVEL_UNKNOWN:
-            return "<unknown>";
-    }
-}
-
 static bool _parseUEFunctionalityLevel( char * pQUEFunctionalityLevelPayload,
                                         BG770UEFunctionalityLevel_t *const pUEFunctionalityLevel )
 {
@@ -2084,9 +2082,32 @@ CellularError_t CellularModule_GetUEFunctionalityLevel( CellularHandle_t cellula
 
 /*-----------------------------------------------------------*/
 
+#ifdef CELLULAR_CONFIG_FORCE_FUNCTIONALITY_LEVEL_SIM_ONLY_RF_OFF
+
 static CellularError_t _SetDesiredUEFunctionalityLevel( CellularHandle_t cellularHandle, uint32_t commandTimeoutMS )
 {
-    return _SetUEFunctionalityLevel( cellularHandle, DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL, commandTimeoutMS );     // TODO (MV): Need to no longer do this here? Be smarter about whether in PSM or eDRX and not do this
+    return _SetUEFunctionalityLevel( cellularHandle, DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL, commandTimeoutMS );
+}
+
+static const char * _getUEFunctionalityLevelString( const BG770UEFunctionalityLevel_t ueFunctionalityLevel )
+{
+    switch( ueFunctionalityLevel )
+    {
+    case BG770_UE_FUNCTIONALITY_LEVEL_MINIMUM:
+        return UE_FUNC_LEVEL_MINIMUM_STRING;
+
+    case BG770_UE_FUNCTIONALITY_LEVEL_FULL:
+        return UE_FUNC_LEVEL_FULL_STRING;
+
+    case BG770_UE_FUNCTIONALITY_LEVEL_SIM_ONLY:
+        return UE_FUNC_LEVEL_SIM_ONLY_STRING;
+
+    default:
+        LogError( ( "_getUEFunctionalityLevelString: Invalid BG770UEFunctionalityLevel_t: %d", ueFunctionalityLevel ) );
+        /**< Intentional fall-through */
+    case BG770_UE_FUNCTIONALITY_LEVEL_UNKNOWN:
+        return "<unknown>";
+    }
 }
 
 static CellularError_t _SetUEFunctionalityLevel( CellularHandle_t cellularHandle,
@@ -2133,6 +2154,8 @@ static CellularError_t _SetUEFunctionalityLevel( CellularHandle_t cellularHandle
 
     return cellularStatus;
 }
+
+#endif
 
 /*-----------------------------------------------------------*/
 

--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -1070,6 +1070,8 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
         NULL,
         0
     };
+    bool isPsmUrcEnabled = false;
+    bool desiredIsPsmUrcEnabled = false;
 
     if( configSkipPostHWFlowControlSetupIfChanged && fullInitSkippedResult == CELLULAR_FULL_INIT_SKIPPED_RESULT_YES )
     {
@@ -1102,7 +1104,12 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
      *  +CEREG: <stat>[,[<tac>],[<ci>],[<AcT>][,,[,[<Active-Time>],[<Periodic-TAU>]]]]
      * NOTE: Command is not automatically saved, therefore, don't need read-before-write behavior
      */
+#ifdef CELLULAR_CONFIG_ALLOW_BG770_PSM
     atReqGetNoResult.pAtCmd = "AT+CEREG=4";
+#else
+    atReqGetNoResult.pAtCmd = "AT+CEREG=2";
+#endif
+
     pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
     if( pktStatus == CELLULAR_PKT_STATUS_OK )
     {
@@ -1149,12 +1156,18 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
 
     vTaskDelay( SHORT_DELAY_ticks );
 
+#ifdef CELLULAR_CONFIG_ALLOW_BG770_PSM
     /* Enable PSM URC reporting by unsolicited result code +QPSMTIMER: <TAU_timer>,<T3324_timer> */
     atReqGetNoResult.pAtCmd = "AT+QCFG=\"psm/urc\",1";
+    desiredIsPsmUrcEnabled = true;
+#else
+    /* Disable PSM URC reporting */
+    atReqGetNoResult.pAtCmd = "AT+QCFG=\"psm/urc\",0";
+    desiredIsPsmUrcEnabled = false;
+#endif
 
-    bool isPsmUrcEnabled = false;
     cellularStatus = _GetPsmUrcEnabled(pContext, &isPsmUrcEnabled );
-    if( ( cellularStatus != CELLULAR_SUCCESS ) || ( isPsmUrcEnabled != true /* extra thorough condition */ ) )
+    if( ( cellularStatus != CELLULAR_SUCCESS ) || ( isPsmUrcEnabled != desiredIsPsmUrcEnabled ) )
     {
         vTaskDelay( SHORT_DELAY_ticks );
 

--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -354,7 +354,7 @@ static const char * getCellularErrorString( const CellularError_t cellularError 
 
 /*-----------------------------------------------------------*/
 
-static const char * getCellularPacketStatusString( const CellularPktStatus_t packetStatus ) {
+const char * CellularModule_GetCellularPacketStatusString( const CellularPktStatus_t packetStatus ) {
     switch (packetStatus) {
         case CELLULAR_PKT_STATUS_OK:
             return "OK";
@@ -1023,7 +1023,7 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             atReqGetNoResult.pAtCmd = "AT+QCFG=\"lwm2m\",0";
 
             bool isLwM2MEnabled = false;
-            const CellularError_t getLwM2MEnableStatus = _GetLwM2MEnabled(pContext, &isLwM2MEnabled );
+            CellularError_t getLwM2MEnableStatus = _GetLwM2MEnabled(pContext, &isLwM2MEnabled );
             if( getLwM2MEnableStatus != CELLULAR_SUCCESS || isLwM2MEnabled )
             {
                 vTaskDelay( SHORT_DELAY_ticks );
@@ -1092,7 +1092,7 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
     else
     {
         LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
-                     atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
+                     atReqGetNoResult.pAtCmd, CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
     }
 
     vTaskDelay( SHORT_DELAY_ticks );
@@ -1118,7 +1118,7 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
     else
     {
         LogError( ( "Cellular_ModuleEnableUrc: '%s' error, pktStatus: %s [%d]",
-                     atReqGetNoResult.pAtCmd, getCellularPacketStatusString(pktStatus), pktStatus ) );
+                     atReqGetNoResult.pAtCmd, CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
     }
 
     vTaskDelay( SHORT_DELAY_ticks );
@@ -1342,7 +1342,7 @@ static CellularError_t _GetLwM2MEnabled( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_GetLwM2MEnabled: couldn't retrieve L2M2M enable (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -1557,7 +1557,7 @@ static CellularError_t _GetURCIndicationOption( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_GetURCIndicationOption: couldn't retrieve URC indication option (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -1609,7 +1609,7 @@ static CellularError_t _SetURCIndicationOption( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_SetURCIndicationOption: couldn't set URC indication option (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -1848,7 +1848,7 @@ static CellularError_t _GetFlowControlState( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_GetFlowControlState: couldn't retrieve flow control state (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -1896,7 +1896,7 @@ static CellularError_t _SetFlowControlState( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_SetFlowControlState: couldn't set flow control state (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2077,7 +2077,7 @@ CellularError_t CellularModule_GetUEFunctionalityLevel( CellularHandle_t cellula
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_GetUEFunctionalityLevel: couldn't retrieve UE functionality level (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2152,7 +2152,7 @@ static CellularError_t _SetUEFunctionalityLevel( CellularHandle_t cellularHandle
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_SetUEFunctionalityLevel: couldn't set UE functionality level (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2373,7 +2373,7 @@ static CellularError_t _GetNetworkCategorySearchMode( CellularHandle_t cellularH
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_GetNetworkCategorySearchMode: couldn't retrieve network category search mode (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2429,7 +2429,7 @@ static CellularError_t _SetNetworkCategorySearchMode( CellularHandle_t cellularH
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_SetNetworkCategorySearchMode: couldn't set network category search mode (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2891,7 +2891,7 @@ static CellularError_t _GetRATScanSequence( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_GetRATScanSequence: couldn't retrieve RAT scan sequence (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2949,7 +2949,7 @@ static CellularError_t _SetRATScanSequence( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_SetRATScanSequence: couldn't set RAT scan sequence (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -3108,7 +3108,7 @@ static CellularError_t _GetPsmUrcEnabled( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_GetPsmUrcEnabled: couldn't retrieve PSM URC enable (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -3255,7 +3255,7 @@ static CellularError_t _GetTimeZoneReportingMode( CellularHandle_t cellularHandl
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "_GetTimeZoneReportingMode: couldn't retrieve time zone reporting mode (pktStatus: %s [%d]).",
-                        getCellularPacketStatusString(pktStatus), pktStatus ) );
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }

--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -41,7 +41,6 @@
 /*-----------------------------------------------------------*/
 
 #define ENABLE_MODULE_UE_RETRY_COUNT       ( 4U )
-#define ENABLE_MODULE_UE_RETRY_TIMEOUT_MS   ( 18000U )   /* observed at least 17113 ms */
 #define ENABLE_MODULE_UE_RETRY_EXP_BACKOFF_INTER_COMMAND_BASE_MS    ( 1000UL )
 #define BG770_NWSCANSEQ_CMD_MAX_SIZE       ( 30U ) /* Need at least the length of AT+QCFG="nwscanseq",020301,1\0. */
 
@@ -98,14 +97,6 @@ typedef struct BG770FlowControlState
     BG770FlowControlType_t dceByDTE;        /**< RTS if hardware flow control. */
     BG770FlowControlType_t dteByDCE;        /**< CTS if hardware flow control. */
 } BG770FlowControlState_t;
-
-typedef enum BG770UEFunctionalityLevel
-{
-    BG770_UE_FUNCTIONALITY_LEVEL_MINIMUM = 0,     /**< RF front-end and SIM card disabled */
-    BG770_UE_FUNCTIONALITY_LEVEL_FULL = 1,        /**< RF front-end and SIM card enabled */
-    BG770_UE_FUNCTIONALITY_LEVEL_SIM_ONLY = 4,    /**< RF front-end disabled and SIM card enabled */
-    BG770_UE_FUNCTIONALITY_LEVEL_UNKNOWN,         /**< Unknown/unsupported functionality type. */
-} BG770UEFunctionalityLevel_t;
 
 static const char *const UE_FUNC_LEVEL_MINIMUM_STRING = "0";
 static const char *const UE_FUNC_LEVEL_FULL_STRING = "1";
@@ -209,10 +200,6 @@ static CellularError_t _GetFlowControlStateWithRetryTimeout( CellularHandle_t ce
 
 static CellularError_t _SetFlowControlState( CellularHandle_t cellularHandle,
                                              BG770FlowControlState_t flowControlState );
-
-static CellularError_t _GetUEFunctionalityLevel( CellularHandle_t cellularHandle,
-                                                 BG770UEFunctionalityLevel_t * pUEFunctionalityLevel,
-                                                 uint32_t commandTimeoutMS );
 
 static CellularError_t _GetUEFunctionalityLevelWithRetryTimeout( CellularHandle_t cellularHandle,
                                                                  BG770UEFunctionalityLevel_t * pUEFunctionalityLevel,
@@ -746,33 +733,39 @@ CellularError_t Cellular_ModuleEnableUE( CellularContext_t * pContext )
             cellularStatus = _GetUEFunctionalityLevelWithRetryTimeout(
                     pContext, &ueFunctionalityLevel, ENABLE_MODULE_UE_RETRY_TIMEOUT_MS,
                     ENABLE_MODULE_UE_RETRY_EXP_BACKOFF_INTER_COMMAND_BASE_MS );
-            if( cellularStatus != CELLULAR_SUCCESS ||
-                DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL != ueFunctionalityLevel )
+            if( cellularStatus == CELLULAR_SUCCESS )
             {
-                if( cellularStatus != CELLULAR_SUCCESS )
-                {
-                    LogError( ( "Cellular_ModuleEnableUE: Could not get UE functionality level, assuming not already set." ) );
-                }
+                LogInfo( ( "Cellular_ModuleEnableUE: UE functionality level (%d) on boot.", ueFunctionalityLevel ) );
+            }
 
-                cellularStatus = setRetryableSettingWithTimeoutParams(
-                        _SetDesiredUEFunctionalityLevel, pContext, ENABLE_MODULE_UE_RETRY_TIMEOUT_MS,
-                        ENABLE_MODULE_UE_RETRY_EXP_BACKOFF_INTER_COMMAND_BASE_MS );
-                if( cellularStatus == CELLULAR_SUCCESS )
-                {
-                    LogInfo( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command success.", DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL ) );
-                }
-                else
-                {
-                    LogError( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command failure (err: %s [%d]), current level: %d.",
-                                DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL,
-                                getCellularErrorString(cellularStatus), cellularStatus,
-                                ueFunctionalityLevel ) );
-                }
-            }
-            else
-            {
-                LogInfo( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command skipped, already set.", DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL ) );
-            }
+            // TODO (MV): Fix this
+            // if( cellularStatus != CELLULAR_SUCCESS ||
+            //     DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL != ueFunctionalityLevel )
+            // {
+            //     if( cellularStatus != CELLULAR_SUCCESS )
+            //     {
+            //         LogError( ( "Cellular_ModuleEnableUE: Could not get UE functionality level, assuming not already set." ) );
+            //     }
+            //
+            //     cellularStatus = setRetryableSettingWithTimeoutParams(
+            //             _SetDesiredUEFunctionalityLevel, pContext, ENABLE_MODULE_UE_RETRY_TIMEOUT_MS,
+            //             ENABLE_MODULE_UE_RETRY_EXP_BACKOFF_INTER_COMMAND_BASE_MS );
+            //     if( cellularStatus == CELLULAR_SUCCESS )
+            //     {
+            //         LogInfo( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command success.", DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL ) );
+            //     }
+            //     else
+            //     {
+            //         LogError( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command failure (err: %s [%d]), current level: %d.",
+            //                     DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL,
+            //                     getCellularErrorString(cellularStatus), cellularStatus,
+            //                     ueFunctionalityLevel ) );
+            //     }
+            // }
+            // else
+            // {
+            //     LogInfo( ( "Cellular_ModuleEnableUE: Set UE functionality level (%d) command skipped, already set.", DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL ) );
+            // }
         }
         else
         {
@@ -1075,7 +1068,9 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
     ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
 
     /* Enable LTE network registration and location information unsolicited result code:
-        +CEREG: <stat>[,[<tac>],[<ci>],[<AcT>]]
+     // TODO (MV): Finish this
+    +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>[,<cause_type>,<reject_cause>]]]
+    +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>[,<cause_type>,<reject_cause>]]]
      */
     atReqGetNoResult.pAtCmd = "AT+CEREG=2";
     ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
@@ -1084,7 +1079,7 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
     atReqGetNoResult.pAtCmd = "AT+CTZR=1";
     ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
 
-    /* Disable PSM URC reporting by unsolicited result code +QPSMTIMER: <TAU_timer>,<T3324_timer> */
+    /* Enable PSM URC reporting by unsolicited result code +QPSMTIMER: <TAU_timer>,<T3324_timer> */
     atReqGetNoResult.pAtCmd = "AT+QCFG=\"psm/urc\",1";  // TODO (MV): Fix this
     ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
 
@@ -1954,7 +1949,7 @@ static CellularError_t _GetUEFunctionalityLevelWithRetryTimeout( CellularHandle_
                 vTaskDelay( pdMS_TO_TICKS( exponentialBackoffInterCommandBaseMS * (uint32_t)tryCount * tryCount ) );
             }
 
-            cellularStatus = _GetUEFunctionalityLevel( cellularHandle, pUEFunctionalityLevel, commandTimeoutMS );
+            cellularStatus = CellularModule_GetUEFunctionalityLevel( cellularHandle, pUEFunctionalityLevel, commandTimeoutMS );
 
             if( cellularStatus == CELLULAR_SUCCESS )
             {
@@ -1966,9 +1961,9 @@ static CellularError_t _GetUEFunctionalityLevelWithRetryTimeout( CellularHandle_
     return cellularStatus;
 }
 
-static CellularError_t _GetUEFunctionalityLevel( CellularHandle_t cellularHandle,
-                                                 BG770UEFunctionalityLevel_t *const pUEFunctionalityLevel,
-                                                 uint32_t commandTimeoutMS )
+CellularError_t CellularModule_GetUEFunctionalityLevel( CellularHandle_t cellularHandle,
+                                                        BG770UEFunctionalityLevel_t *const pUEFunctionalityLevel,
+                                                        uint32_t commandTimeoutMS )
 {
     CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
     CellularError_t cellularStatus = CELLULAR_SUCCESS;
@@ -2006,7 +2001,7 @@ static CellularError_t _GetUEFunctionalityLevel( CellularHandle_t cellularHandle
 
 static CellularError_t _SetDesiredUEFunctionalityLevel( CellularHandle_t cellularHandle, uint32_t commandTimeoutMS )
 {
-    return _SetUEFunctionalityLevel( cellularHandle, DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL, commandTimeoutMS );
+    return _SetUEFunctionalityLevel( cellularHandle, DESIRED_UE_ENABLE_FUNCTIONALITY_LEVEL, commandTimeoutMS );     // TODO (MV): Need to no longer do this here? Be smarter about whether in PSM or eDRX and not do this
 }
 
 static CellularError_t _SetUEFunctionalityLevel( CellularHandle_t cellularHandle,

--- a/source/cellular_bg770.c
+++ b/source/cellular_bg770.c
@@ -1062,6 +1062,8 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
 
     /* FUTURE: Turn all of these commands into read before write */
 
+    // TODO (MV): Make these indicate error if occurs
+
     /* Set numeric operator format. */
     atReqGetNoResult.pAtCmd = "AT+COPS=3,2";
     ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
@@ -1083,8 +1085,7 @@ CellularError_t Cellular_ModuleEnableUrc( CellularContext_t * pContext )
     ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
 
     /* Disable PSM URC reporting by unsolicited result code +QPSMTIMER: <TAU_timer>,<T3324_timer> */
-    /* FUTURE: Enable (1) when PSM used */
-    atReqGetNoResult.pAtCmd = "AT+QCFG=\"psm/urc\",0";
+    atReqGetNoResult.pAtCmd = "AT+QCFG=\"psm/urc\",1";  // TODO (MV): Fix this
     ( void ) _Cellular_AtcmdRequestWithCallback( pContext, atReqGetNoResult );
 
     return cellularStatus;

--- a/source/cellular_bg770.h
+++ b/source/cellular_bg770.h
@@ -63,6 +63,8 @@
 
 #define PSM_VERSION_BIT_MASK               ( 0b00001111u )
 
+#define ENABLE_MODULE_UE_RETRY_TIMEOUT_MS   ( 18000U )   /* observed at least 17113 ms */
+
 #include <cellular_types.h>
 #include "cellular_platform.h"
 #include "cellular_common.h"
@@ -84,6 +86,14 @@ typedef enum CellularModuleFullInitSkippedResult
     CELLULAR_FULL_INIT_SKIPPED_RESULT_NO,
     CELLULAR_FULL_INIT_SKIPPED_RESULT_ERROR     /* Error caused yes/no result to be irrelevant */
 } CellularModuleFullInitSkippedResult_t;
+
+typedef enum BG770UEFunctionalityLevel
+{
+    BG770_UE_FUNCTIONALITY_LEVEL_MINIMUM = 0,     /**< RF front-end and SIM card disabled */
+    BG770_UE_FUNCTIONALITY_LEVEL_FULL = 1,        /**< RF front-end and SIM card enabled */
+    BG770_UE_FUNCTIONALITY_LEVEL_SIM_ONLY = 4,    /**< RF front-end disabled and SIM card enabled */
+    BG770_UE_FUNCTIONALITY_LEVEL_UNKNOWN,         /**< Unknown/unsupported functionality type. */
+} BG770UEFunctionalityLevel_t;
 
 typedef struct cellularModuleContext cellularModuleContext_t;
 
@@ -151,6 +161,10 @@ CellularError_t CellularModule_SkipInitializationPostHWFlowControlSetupIfChanged
  */
 CellularError_t CellularModule_TryGetDidSkipInitializationPostHWFlowControlSetup(
         CellularModuleFullInitSkippedResult_t * pSkippedResult);
+
+CellularError_t CellularModule_GetUEFunctionalityLevel( CellularHandle_t cellularHandle,
+                                                        BG770UEFunctionalityLevel_t * pUEFunctionalityLevel,
+                                                        uint32_t commandTimeoutMS );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/cellular_bg770.h
+++ b/source/cellular_bg770.h
@@ -166,6 +166,8 @@ CellularError_t CellularModule_GetUEFunctionalityLevel( CellularHandle_t cellula
                                                         BG770UEFunctionalityLevel_t * pUEFunctionalityLevel,
                                                         uint32_t commandTimeoutMS );
 
+const char * CellularModule_GetCellularPacketStatusString( CellularPktStatus_t packetStatus );
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     }

--- a/source/cellular_bg770_api.c
+++ b/source/cellular_bg770_api.c
@@ -1704,7 +1704,7 @@ static CellularATError_t parseQpsmsTau( char * pToken,
         }
         else
         {
-            LogError( ( "Error in processing Periodic TAU value value. Token %s", pToken ) );
+            LogError( ( "Error in processing Periodic TAU value. Token %s", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }
@@ -1815,7 +1815,7 @@ static CellularATError_t parseCpsmsTau( char * pToken,
         }
         else
         {
-            LogError( ( "Error in processing Requested Periodic TAU value value. Token %s", pToken ) );
+            LogError( ( "Error in processing Requested Periodic TAU value. Token %s", pToken ) );
             atCoreStatus = CELLULAR_AT_ERROR;
         }
     }

--- a/source/cellular_bg770_api.c
+++ b/source/cellular_bg770_api.c
@@ -85,11 +85,19 @@
 #define PRINTF_BYTE_TO_BINARY_INT8( i ) \
     PRINTF_BYTE_TO_BINARY_INT4( ( i ) >> 4 ), PRINTF_BYTE_TO_BINARY_INT4( i )
 
+/* Network PSM settings */
 #define QPSMS_POS_MODE                           ( 0U )
 #define QPSMS_POS_RAU                            ( 1U )
 #define QPSMS_POS_RDY_TIMER                      ( 2U )
 #define QPSMS_POS_TAU                            ( 3U )
 #define QPSMS_POS_ACTIVE_TIME                    ( 4U )
+
+/* Requested PSM settings */
+#define CPSMS_POS_MODE                           ( 0U )
+#define CPSMS_POS_RAU                            ( 1U )
+#define CPSMS_POS_RDY_TIMER                      ( 2U )
+#define CPSMS_POS_TAU                            ( 3U )
+#define CPSMS_POS_ACTIVE_TIME                    ( 4U )
 
 #define CELLULAR_PDN_STATUS_POS_CONTEXT_ID       ( 0U )
 #define CELLULAR_PDN_STATUS_POS_CONTEXT_STATE    ( 1U )
@@ -223,6 +231,19 @@ static CellularATError_t parseQpsmsActiveTime( char * pToken,
 static CellularATError_t parseGetPsmToken( char * pToken,
                                            uint8_t tokenIndex,
                                            CellularPsmSettings_t * pPsmSettings );
+static CellularATError_t parseCpsmsMode( char * pToken,
+                                         CellularPsmSettings_t * pPsmSettings );
+static CellularATError_t parseCpsmsRau( char * pToken,
+                                        CellularPsmSettings_t * pPsmSettings );
+static CellularATError_t parseCpsmsRdyTimer( char * pToken,
+                                             CellularPsmSettings_t * pPsmSettings );
+static CellularATError_t parseCpsmsTau( char * pToken,
+                                        CellularPsmSettings_t * pPsmSettings );
+static CellularATError_t parseCpsmsActiveTime( char * pToken,
+                                               CellularPsmSettings_t * pPsmSettings );
+static CellularATError_t parseGetRequestedPsmToken( char * pToken,
+                                                    uint8_t tokenIndex,
+                                                    CellularPsmSettings_t * pPsmSettings );
 static CellularRat_t convertRatPriority( char * pRatString );
 static CellularPktStatus_t _Cellular_RecvFuncGetRatPriority( CellularContext_t * pContext,
                                                              const CellularATCommandResponse_t * pAtResp,
@@ -1756,6 +1777,117 @@ static CellularATError_t parseGetPsmToken( char * pToken,
 
 /*-----------------------------------------------------------*/
 
+static CellularATError_t parseCpsmsMode( char * pToken,
+                                         CellularPsmSettings_t * pPsmSettings )
+{
+    return parseQpsmsMode( pToken, pPsmSettings );
+}
+
+/*-----------------------------------------------------------*/
+
+static CellularATError_t parseCpsmsRau( char * pToken,
+                                        CellularPsmSettings_t * pPsmSettings )
+{
+    return parseQpsmsRau( pToken, pPsmSettings );
+}
+
+/*-----------------------------------------------------------*/
+
+static CellularATError_t parseCpsmsRdyTimer( char * pToken,
+                                             CellularPsmSettings_t * pPsmSettings )
+{
+    return parseQpsmsRdyTimer( pToken, pPsmSettings );
+}
+
+/*-----------------------------------------------------------*/
+
+static CellularATError_t parseCpsmsTau( char * pToken,
+                                        CellularPsmSettings_t * pPsmSettings )
+{
+    int32_t tempValue = 0;
+    CellularATError_t atCoreStatus = Cellular_ATStrtoi( pToken, 2, &tempValue );
+
+    if( atCoreStatus == CELLULAR_AT_SUCCESS )
+    {
+        if( ( tempValue >= 0 ) && ( tempValue <= UINT8_MAX ) )
+        {
+            pPsmSettings->periodicTauValue = ( uint32_t ) tempValue;
+        }
+        else
+        {
+            LogError( ( "Error in processing Requested Periodic TAU value value. Token %s", pToken ) );
+            atCoreStatus = CELLULAR_AT_ERROR;
+        }
+    }
+
+    return atCoreStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+static CellularATError_t parseCpsmsActiveTime( char * pToken,
+                                               CellularPsmSettings_t * pPsmSettings )
+{
+    int32_t tempValue = 0;
+    CellularATError_t atCoreStatus = Cellular_ATStrtoi( pToken, 2, &tempValue );
+
+    if( atCoreStatus == CELLULAR_AT_SUCCESS )
+    {
+        if( ( tempValue >= 0 ) && ( tempValue <= UINT8_MAX ) )
+        {
+            pPsmSettings->activeTimeValue = ( uint32_t ) tempValue;
+        }
+        else
+        {
+            LogError( ( "Error in processing Requested Periodic Processing Active time value. Token %s", pToken ) );
+            atCoreStatus = CELLULAR_AT_ERROR;
+        }
+    }
+
+    return atCoreStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+static CellularATError_t parseGetRequestedPsmToken( char * pToken,
+                                                    uint8_t tokenIndex,
+                                                    CellularPsmSettings_t * pPsmSettings )
+{
+    CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
+
+    switch( tokenIndex )
+    {
+        case CPSMS_POS_MODE:
+            atCoreStatus = parseCpsmsMode( pToken, pPsmSettings );
+            break;
+
+        case CPSMS_POS_RAU:
+            atCoreStatus = parseCpsmsRau( pToken, pPsmSettings );
+            break;
+
+        case CPSMS_POS_RDY_TIMER:
+            atCoreStatus = parseCpsmsRdyTimer( pToken, pPsmSettings );
+            break;
+
+        case CPSMS_POS_TAU:
+            atCoreStatus = parseCpsmsTau( pToken, pPsmSettings );
+            break;
+
+        case CPSMS_POS_ACTIVE_TIME:
+            atCoreStatus = parseCpsmsActiveTime( pToken, pPsmSettings );
+            break;
+
+        default:
+            LogDebug( ( "Unknown Parameter Position in AT+CPSMS Response" ) );
+            atCoreStatus = CELLULAR_AT_ERROR;
+            break;
+    }
+
+    return atCoreStatus;
+}
+
+/*-----------------------------------------------------------*/
+
 static CellularRat_t convertRatPriority( char * pRatString )
 {
     CellularRat_t retRat = CELLULAR_RAT_INVALID;
@@ -1931,6 +2063,95 @@ static CellularPktStatus_t _Cellular_RecvFuncGetPsmSettings( CellularContext_t *
         }
 
         LogDebug( ( "PSM setting: mode: %d, RAU: %d, RDY_Timer: %d, TAU: %d, Active_time: %d",
+                    pPsmSettings->mode,
+                    pPsmSettings->periodicRauValue,
+                    pPsmSettings->gprsReadyTimer,
+                    pPsmSettings->periodicTauValue,
+                    pPsmSettings->activeTimeValue ) );
+        pktStatus = _Cellular_TranslateAtCoreStatus( atCoreStatus );
+    }
+
+    return pktStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+/* FreeRTOS Cellular Library types. */
+/* coverity[misra_c_2012_rule_8_13_violation] */
+static CellularPktStatus_t _Cellular_RecvFuncGetRequestedPsmSettings( CellularContext_t * pContext,
+                                                                      const CellularATCommandResponse_t * pAtResp,
+                                                                      void * pData,
+                                                                      uint16_t dataLen )
+{
+    char * pInputLine = NULL, * pToken = NULL;
+    uint8_t tokenIndex = 0;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularATError_t atCoreStatus = CELLULAR_AT_SUCCESS;
+    CellularPsmSettings_t * pPsmSettings = NULL;
+
+    if( pContext == NULL )
+    {
+        LogError( ( "GetRequestedPsmSettings: Invalid context" ) );
+        pktStatus = CELLULAR_PKT_STATUS_FAILURE;
+    }
+    else if( ( pAtResp == NULL ) || ( pAtResp->pItm == NULL ) ||
+             ( pAtResp->pItm->pLine == NULL ) || ( pData == NULL ) || ( dataLen != sizeof( CellularPsmSettings_t ) ) )
+    {
+        LogError( ( "GetRequestedPsmSettings: Invalid param" ) );
+        pktStatus = CELLULAR_PKT_STATUS_BAD_PARAM;
+    }
+    else
+    {
+        pInputLine = pAtResp->pItm->pLine;
+        pPsmSettings = ( CellularPsmSettings_t * ) pData;
+        atCoreStatus = Cellular_ATRemovePrefix( &pInputLine );
+
+        if( atCoreStatus == CELLULAR_AT_SUCCESS )
+        {
+            atCoreStatus = Cellular_ATRemoveAllDoubleQuote( pInputLine );
+        }
+
+        if( atCoreStatus == CELLULAR_AT_SUCCESS )
+        {
+            atCoreStatus = Cellular_ATGetNextTok( &pInputLine, &pToken );
+        }
+
+        if( atCoreStatus == CELLULAR_AT_SUCCESS )
+        {
+            tokenIndex = 0;
+
+            while( pToken != NULL )
+            {
+                if( tokenIndex == 0 )
+                {
+                    atCoreStatus = parseGetRequestedPsmToken( pToken, tokenIndex, pPsmSettings );
+                }
+                else
+                {
+                    parseGetRequestedPsmToken( pToken, tokenIndex, pPsmSettings );
+                }
+
+                tokenIndex++;
+
+                if( *pInputLine == ',' )
+                {
+                    *pInputLine = '\0';
+                    pToken = pInputLine;
+                    *pToken = '\0';
+                    pInputLine = &pInputLine[ 1 ];
+                }
+                else if( Cellular_ATGetNextTok( &pInputLine, &pToken ) != CELLULAR_AT_SUCCESS )
+                {
+                    break;
+                }
+                else
+                {
+                    /* Empty Else MISRA 15.7 */
+                }
+            }
+        }
+
+        LogDebug( ( "Requested PSM setting: mode: %d, RAU: %d, RDY_Timer: %d, TAU: 0x%x, Active_time: 0x%x",
                     pPsmSettings->mode,
                     pPsmSettings->periodicRauValue,
                     pPsmSettings->gprsReadyTimer,
@@ -2648,6 +2869,53 @@ CellularError_t Cellular_GetPsmSettings( CellularHandle_t cellularHandle,
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
             LogError( ( "Cellular_GetPsmSettings: couldn't retrieve PSM settings" ) );
+            cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
+        }
+    }
+
+    return cellularStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+CellularError_t Cellular_GetRequestedPsmSettings( CellularHandle_t cellularHandle,
+                                                  CellularPsmSettings_t * pPsmSettings )
+{
+    CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
+    CellularAtReq_t atReqGetPsm =
+    {
+        "AT+CPSMS?",
+        CELLULAR_AT_WITH_PREFIX,
+        "+CPSMS",
+        _Cellular_RecvFuncGetRequestedPsmSettings,
+        pPsmSettings,
+        sizeof( CellularPsmSettings_t ),
+    };
+
+    cellularStatus = _Cellular_CheckLibraryStatus( pContext );
+
+    if( cellularStatus != CELLULAR_SUCCESS )
+    {
+        LogDebug( ( "_Cellular_CheckLibraryStatus failed" ) );
+    }
+    else if( pPsmSettings == NULL )
+    {
+        cellularStatus = CELLULAR_BAD_PARAMETER;
+    }
+    else
+    {
+        /* initialize the data. */
+        ( void ) memset( pPsmSettings, 0, sizeof( CellularPsmSettings_t ) );
+        pPsmSettings->mode = 0xFF;
+
+        /* we should always query the PSMsettings from the network. */
+        pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetPsm );
+
+        if( pktStatus != CELLULAR_PKT_STATUS_OK )
+        {
+            LogError( ( "Cellular_GetRequestedPsmSettings: couldn't retrieve requested PSM settings" ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }

--- a/source/cellular_bg770_api.c
+++ b/source/cellular_bg770_api.c
@@ -3087,9 +3087,18 @@ CellularError_t Cellular_SetPsmSettings( CellularHandle_t cellularHandle,
         /* The return value of snprintf is not used.
          * The max length of the string is fixed and checked offline. */
         /* coverity[misra_c_2012_rule_21_6_violation]. */
-        ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+QPSMS=%d", pPsmSettings->mode );
+        if( pPsmSettings->mode == 0 )
+        {
+            ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+QPSMS=" ); // special version of the command that disables PSM and clears the parameters
+        }
+        else
+        {
+            ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "AT+QPSMS=%d", pPsmSettings->mode );
+        }
+
         cmdBufLen = strlen( cmdBuf );
-        if (pPsmSettings->periodicTauValue != 0 || pPsmSettings->activeTimeValue != 0) {
+        if( pPsmSettings->mode != 0 && ( ( pPsmSettings->periodicTauValue != 0 ) || ( pPsmSettings->activeTimeValue != 0 ) ) )
+        {
             (void) strcat(cmdBuf, ",");     // FUTURE: Improve robustness of this
             cmdBufLen++;
             cmdBufLen += appendBinaryPattern(&cmdBuf[cmdBufLen], (CELLULAR_AT_CMD_MAX_SIZE - cmdBufLen), 0, false);    // NOTE: BG770 doesn't support this parameter
@@ -4417,6 +4426,34 @@ CellularError_t Cellular_GetRfFunctionality( CellularHandle_t cellularHandle,
                     break;
             }
         }
+    }
+
+    return cellularStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+CellularError_t Cellular_SimAndRfOff( CellularHandle_t cellularHandle )
+{
+    CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    CellularError_t cellularStatus;
+    CellularPktStatus_t pktStatus;
+    CellularAtReq_t atReq = { 0 };
+
+    atReq.pAtCmd = "AT+CFUN=0";
+    atReq.atCmdType = CELLULAR_AT_NO_RESULT;
+    atReq.pAtRspPrefix = NULL;
+    atReq.respCallback = NULL;
+    atReq.pData = NULL;
+    atReq.dataLen = 0;
+
+    /* Make sure library is open. */
+    cellularStatus = _Cellular_CheckLibraryStatus( pContext );
+
+    if( cellularStatus == CELLULAR_SUCCESS )
+    {
+        pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReq );
+        cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
     }
 
     return cellularStatus;

--- a/source/cellular_bg770_api.c
+++ b/source/cellular_bg770_api.c
@@ -2910,12 +2910,13 @@ CellularError_t Cellular_GetRequestedPsmSettings( CellularHandle_t cellularHandl
         ( void ) memset( pPsmSettings, 0, sizeof( CellularPsmSettings_t ) );
         pPsmSettings->mode = 0xFF;
 
-        /* we should always query the PSMsettings from the network. */
+        /* we should always query the requested PSM settings. */
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReqGetPsm );
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "Cellular_GetRequestedPsmSettings: couldn't retrieve requested PSM settings" ) );
+            LogError( ( "Cellular_GetRequestedPsmSettings: couldn't retrieve requested PSM settings (pktStatus: %s [%d]).",
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -2964,7 +2965,8 @@ CellularError_t Cellular_GetPsmConfigSettings( CellularHandle_t cellularHandle,
 
         if( pktStatus != CELLULAR_PKT_STATUS_OK )
         {
-            LogError( ( "Cellular_GetPsmSettings: couldn't retrieve PSM settings" ) );
+            LogError( ( "Cellular_GetPsmSettings: couldn't retrieve network PSM settings (pktStatus: %s [%d]).",
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
             cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
         }
     }
@@ -3115,7 +3117,8 @@ CellularError_t Cellular_SetPsmSettings( CellularHandle_t cellularHandle,
 
             if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                LogError( ( "Cellular_SetPsmSettings: couldn't set PSM settings" ) );
+                LogError( ( "Cellular_SetPsmSettings: couldn't set PSM settings '%s' (pktStatus: %s [%d]).",
+                            cmdBuf, CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
                 cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
             }
         }
@@ -4436,8 +4439,8 @@ CellularError_t Cellular_GetRfFunctionality( CellularHandle_t cellularHandle,
 CellularError_t Cellular_SimAndRfOff( CellularHandle_t cellularHandle )
 {
     CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
-    CellularError_t cellularStatus;
-    CellularPktStatus_t pktStatus;
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    CellularPktStatus_t pktStatus = CELLULAR_PKT_STATUS_OK;
     CellularAtReq_t atReq = { 0 };
 
     atReq.pAtCmd = "AT+CFUN=0";
@@ -4453,7 +4456,12 @@ CellularError_t Cellular_SimAndRfOff( CellularHandle_t cellularHandle )
     if( cellularStatus == CELLULAR_SUCCESS )
     {
         pktStatus = _Cellular_AtcmdRequestWithCallback( pContext, atReq );
-        cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
+        if( pktStatus != CELLULAR_PKT_STATUS_OK )
+        {
+            LogError( ( "Cellular_SimAndRfOff: couldn't set CFUN=0 (pktStatus: %s [%d]).",
+                        CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
+            cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
+        }
     }
 
     return cellularStatus;
@@ -7144,7 +7152,8 @@ CellularError_t Cellular_SetServiceSelection( CellularHandle_t cellularHandle,
 
             if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                LogError( ( "Cellular_SetServiceSelection: couldn't set service selection, err: %d", pktStatus ) );
+                LogError( ( "Cellular_SetServiceSelection: couldn't set service selection (pktStatus: %s [%d]).",
+                            CellularModule_GetCellularPacketStatusString(pktStatus), pktStatus ) );
                 cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
             }
         }

--- a/source/cellular_bg770_api.c
+++ b/source/cellular_bg770_api.c
@@ -4103,6 +4103,59 @@ CellularError_t Cellular_GetPdnStatus( CellularHandle_t cellularHandle,
 
 /*-----------------------------------------------------------*/
 
+CellularError_t Cellular_GetRfFunctionality( CellularHandle_t cellularHandle,
+                                             CellularRfFunctionality_t * pRfFunctionality )
+{
+    CellularContext_t * pContext = ( CellularContext_t * ) cellularHandle;
+    CellularError_t cellularStatus = CELLULAR_SUCCESS;
+    BG770UEFunctionalityLevel_t ueFunctionalityLevel = BG770_UE_FUNCTIONALITY_LEVEL_UNKNOWN;
+
+    /* pContext is checked in _Cellular_CheckLibraryStatus function. */
+    cellularStatus = _Cellular_CheckLibraryStatus( pContext );
+
+    if( cellularStatus != CELLULAR_SUCCESS )
+    {
+        LogDebug( ( "_Cellular_CheckLibraryStatus failed" ) );
+    }
+    else if( pRfFunctionality == NULL )
+    {
+        cellularStatus = CELLULAR_BAD_PARAMETER;
+    }
+    else
+    {
+        cellularStatus = CellularModule_GetUEFunctionalityLevel( cellularHandle,
+                                                                 &ueFunctionalityLevel,
+                                                                 ENABLE_MODULE_UE_RETRY_TIMEOUT_MS );
+        if( cellularStatus == CELLULAR_SUCCESS )
+        {
+            switch( ueFunctionalityLevel )
+            {
+                case BG770_UE_FUNCTIONALITY_LEVEL_MINIMUM:
+                    *pRfFunctionality = CELLULAR_RF_FUNCTIONALITY_OFF;
+                    break;
+
+                case BG770_UE_FUNCTIONALITY_LEVEL_FULL:
+                    *pRfFunctionality = CELLULAR_RF_FUNCTIONALITY_ON;
+                    break;
+
+                case BG770_UE_FUNCTIONALITY_LEVEL_SIM_ONLY:
+                    *pRfFunctionality = CELLULAR_RF_FUNCTIONALITY_SIM_ONLY;
+                    break;
+
+                default:
+                    debugASSERT(false);
+                case BG770_UE_FUNCTIONALITY_LEVEL_UNKNOWN:
+                    cellularStatus = CELLULAR_INTERNAL_FAILURE;
+                    break;
+            }
+        }
+    }
+
+    return cellularStatus;
+}
+
+/*-----------------------------------------------------------*/
+
 /* FreeRTOS Cellular Library API. */
 /* coverity[misra_c_2012_rule_8_7_violation] */
 CellularError_t Cellular_GetSimCardStatus( CellularHandle_t cellularHandle,
@@ -6786,7 +6839,7 @@ CellularError_t Cellular_SetServiceSelection( CellularHandle_t cellularHandle,
 
             if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                LogError( ( "Cellular_SetServiceSelection: couldn't send service selection" ) );
+                LogError( ( "Cellular_SetServiceSelection: couldn't send service selection" ) );    // TODO (MV): Add error
                 cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
             }
         }

--- a/source/cellular_bg770_api.c
+++ b/source/cellular_bg770_api.c
@@ -7139,12 +7139,12 @@ CellularError_t Cellular_SetServiceSelection( CellularHandle_t cellularHandle,
             /* coverity[misra_c_2012_rule_21_6_violation]. */
             ( void ) snprintf( cmdBuf, CELLULAR_AT_CMD_MAX_SIZE, "%s%d,%d,\"%s\"%s",
                                "AT+COPS=", mode, pServiceSelection->operatorNameFormat, operatorString, commaRATString );
-            LogDebug( ( "Cellular_SetPSMEntry: PSM enter command: %s", cmdBuf ) );
+            LogDebug( ( "Cellular_SetServiceSelection: command '%s'", cmdBuf ) );
             pktStatus = _Cellular_TimeoutAtcmdRequestWithCallback( pContext, atReqSetServiceSelection, OPERATOR_SELECTION_PACKET_REQ_TIMEOUT_MS );
 
             if( pktStatus != CELLULAR_PKT_STATUS_OK )
             {
-                LogError( ( "Cellular_SetServiceSelection: couldn't send service selection" ) );    // TODO (MV): Add error
+                LogError( ( "Cellular_SetServiceSelection: couldn't set service selection, err: %d", pktStatus ) );
                 cellularStatus = _Cellular_TranslatePktStatus( pktStatus );
             }
         }

--- a/source/cellular_bg770_urc_handler.c
+++ b/source/cellular_bg770_urc_handler.c
@@ -936,7 +936,7 @@ static void _Cellular_ProcessPSMTimerurc(CellularContext_t * pContext,
     else
     {
         // FUTURE: Pass timer info through modem event callback
-        LogDebug( ( "_Cellular_ProcessPSMTimerurc: Modem PSM timer event received, '%s'", pInputLine ) );
+        LogInfo( ( "_Cellular_ProcessPSMTimerurc: Modem PSM timer event received, '%s'", pInputLine ) );
         _Cellular_ModemEventCallback( pContext, CELLULAR_MODEM_EVENT_PSM_TIMER );
     }
 }

--- a/source/cellular_bg770_wrapper.c
+++ b/source/cellular_bg770_wrapper.c
@@ -110,6 +110,23 @@ CellularError_t Cellular_ATCommandRaw( CellularHandle_t cellularHandle,
 
 /* FreeRTOS Cellular Library API. */
 /* coverity[misra_c_2012_rule_8_7_violation] */
+CellularError_t Cellular_ATCommandRawTimeout( CellularHandle_t cellularHandle,
+                                       const char * pATCommandPrefix,
+                                       const char * pATCommandPayload,
+                                       CellularATCommandType_t atCommandType,
+                                       CellularATCommandResponseReceivedCallback_t responseReceivedCallback,
+                                       void * pData,
+                                       uint16_t dataLen,
+                                       uint32_t timeoutMS )
+{
+    return Cellular_CommonATCommandRawTimeout( cellularHandle, pATCommandPrefix, pATCommandPayload, atCommandType,
+                                               responseReceivedCallback, pData, dataLen, timeoutMS );
+}
+
+/*-----------------------------------------------------------*/
+
+/* FreeRTOS Cellular Library API. */
+/* coverity[misra_c_2012_rule_8_7_violation] */
 CellularError_t Cellular_CreateSocket( CellularHandle_t cellularHandle,
                                        uint8_t pdnContextId,
                                        CellularSocketDomain_t socketDomain,


### PR DESCRIPTION
- moved get UE functionality level (CFUN) functionality to be accessible as part of new FreeRTOS-Cellular-Interface API function [Cellular_GetRfFunctionality(), also improves Quectel FLASH service life]
- added read-before-write functionality for Time Zone URC reporting mode config (improves Quectel FLASH service life)
- added read-before-write functionality for PSM timer URC config (improves Quectel FLASH service life)
- added compile definition support for PSM config
- removed mandatory CFUN=4 (SIM enabled, RF off) during config (improves Quectel FLASH service life), and added compile definition support to force CFUN=4 (used by registration retrieval firmware)
- added implementation for new FreeRTOS-Cellular-Interface API function [Cellular_GetRequestedPsmSettings()] to get desired PSM config settings (previously could only retrieve network specified PSM config settings)
- added implementation for new FreeRTOS-Cellular-Interface API function [Cellular_SimAndRfOff()] used during BG770A module shutdown (when not using PSM, improves Quectel FLASH service life)
- added wrapper for new FreeRTOS-Cellular-Interface common function [Cellular_CommonATCommandRawTimeout()] so that raw AT commands can specify a custom timeout